### PR TITLE
Added support for duplicate headers and Response.append

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ app.listen(8000);
 - ✅ Supports existing Express Router instances
 - Response API
   - ✅ res.headersSent
+  - ✅ res.append()
   - ✅ res.end()
   - ✅ res.get()
   - ✅ res.json()
@@ -45,7 +46,6 @@ app.listen(8000);
   - ✅ res.vary()
   - ❌ res.app
   - ❌ res.locals
-  - ❌ res.append()
   - ❌ res.attachment()
   - ❌ res.cookie()
   - ❌ res.clearCookie()

--- a/src/Response.ts
+++ b/src/Response.ts
@@ -54,7 +54,7 @@ export class ResponseWrapper extends EventEmitter {
     this.get(name);
   }
 
-  setHeader(name: string, value: string) {
+  setHeader(name: string, value: string | string[]) {
     this.set(name, value);
   }
 

--- a/src/Response.ts
+++ b/src/Response.ts
@@ -196,7 +196,7 @@ export class ResponseWrapper extends EventEmitter {
   }
 
   // alias to "set"
-  header(name: string | object, value?: string) {
+  header(name: string | object, value?: string | string[]) {
     return this.set(name, value);
   }
 


### PR DESCRIPTION
Adjusted `Response._headers` structure to allow array values, more closely resembling Express' implementation. This allows for duplicate headers like `set-cookie`. Also added the `append` function to `Response`. Hoping this will pave the way for `Response.cookie`.