### PR TITLE
[Colyseus-422] dropped arrayBuffer when length is 0

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -133,7 +133,7 @@ export class RequestWrapper extends EventEmitter {
 
       this.res.onData((arrayBuffer, isLast) => {
         const chunk = Buffer.from(arrayBuffer);
-        body = body ? Buffer.concat([body, chunk]) : chunk;
+        body = body && body.length !== 0 ? Buffer.concat([body, chunk]) : chunk;
 
         if (isLast) {
           this._rawbody = body.toString();


### PR DESCRIPTION
There is no need to concat when body is 0, also fixes an rare case where body is dropped when isLast=false and arrayBuffer.length 0.

See: https://github.com/colyseus/colyseus/issues/422